### PR TITLE
Migrate to new bring library

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: black
         args: [ "--line-length", "119" ]
   - repo: https://github.com/PyCQA/bandit
-    rev: 1.8.0
+    rev: 1.8.2
     hooks:
       - id: bandit
         args: [ '-c', '.bandit.yml', '-r' ]
@@ -22,6 +22,6 @@ repos:
       - id: flake8
         additional_dependencies: [ flake8-annotations ]
   - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.21.2
+    rev: v8.23.2
     hooks:
       - id: gitleaks

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:3.12-alpine
 
 LABEL org.opencontainers.image.source="https://github.com/felixschndr/mealie-bring-api"
 LABEL org.opencontainers.image.description="The container image of the mealie bring api integration (https://github.com/felixschndr/mealie-bring-api)"

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ Mealie instance to be publicly available (from the internet). Since many users w
 This project provides the source code and a container image for a simple webserver which listens for requests by the 
 Mealie instance and adds the ingredients of a recipe to a specified Bring shopping list.
 
+> [!IMPORTANT]  
+> This integration does only support Mealie version >= `2` which was [released in October 2024](https://github.com/mealie-recipes/mealie/releases/tag/v2.0.0). The support for Mealie version < `2` was deprecated in https://github.com/felixschndr/mealie-bring-api/pull/17.
+
 ## Architecture
 
 ### Without this project

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 flake8==7.0.0
 isort==5.13.2
 black==24.4.2
+bandit=1.8.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.3
-python-bring-api==3.0.0
 python-dotenv==1.0.1
+bring-api==0.9.1
+aiohttp==3.11.10

--- a/source/bring_handler.py
+++ b/source/bring_handler.py
@@ -3,10 +3,9 @@ import sys
 
 import aiohttp
 from bring_api import Bring, BringItemOperation, BringNotificationType
+from environment_variable_getter import EnvironmentVariableGetter
 from ingredient import Ingredient
 from logger_mixin import LoggerMixin
-
-from source.environment_variable_getter import EnvironmentVariableGetter
 
 
 class BringHandler(LoggerMixin):

--- a/source/bring_handler.py
+++ b/source/bring_handler.py
@@ -1,103 +1,67 @@
-import os
+import asyncio
 import sys
 
-from dotenv import load_dotenv
+import aiohttp
+from bring_api import Bring, BringItemOperation, BringNotificationType
 from ingredient import Ingredient
 from logger_mixin import LoggerMixin
-from python_bring_api.bring import Bring
-from python_bring_api.types import BringNotificationType
+
+from source.environment_variable_getter import EnvironmentVariableGetter
 
 
 class BringHandler(LoggerMixin):
-    def __init__(self):
+    def __init__(self, loop: asyncio.AbstractEventLoop):
         super().__init__()
 
-        load_dotenv()
-        self.username = os.getenv("BRING_USERNAME")
-        self.password = os.getenv("BRING_PASSWORD")
-        self.list_name = os.getenv("BRING_LIST_NAME")
-        self.ignored_ingredients_input = os.getenv("IGNORED_INGREDIENTS")
-        self.def_check_if_environment_variables_are_set()
-
-        self.bring = self.login_into_bring()
-
-        self.list_uuid = self.determine_list_uuid()
+        self.bring = loop.run_until_complete(self.initialize())
+        self.list_uuid = loop.run_until_complete(self.determine_list_uuid())
         self.ignored_ingredients = self.parse_ignored_ingredients()
 
-    def def_check_if_environment_variables_are_set(self) -> None:
-        if not self.username or not self.password or not self.list_name:
-            self.log.critical(
-                "Ensure that the environment variables BRING_USERNAME, BRING_PASSWORD and BRING_LIST_NAME are set"
-            )
-            sys.exit(1)
-        self.log.debug("Bring credentials and list name are set")
+    async def initialize(self) -> Bring:
+        username = EnvironmentVariableGetter.get("BRING_USERNAME")
+        password = EnvironmentVariableGetter.get("BRING_PASSWORD")
 
-        if not self.ignored_ingredients_input:
-            self.log.info(
-                'The variable IGNORED_INGREDIENTS is not set. All ingredients will be added. Consider adding something like "Salt,Pepper"'
-            )
-
-    def login_into_bring(self) -> Bring:
-        bring = Bring(self.username, self.password)
+        session = aiohttp.ClientSession()
+        bring = Bring(session, username, password)
         self.log.info("Attempting the login into Bring")
-        bring.login()
+        await bring.login()
         self.log.info("Login successful")
 
         return bring
 
-    def determine_list_uuid(self) -> str:
-        bring_list_uuid = None
-        bring_list_name_lower = self.list_name.lower()
-        for bring_list in self.bring.loadLists()["lists"]:
-            if bring_list["name"].lower() == bring_list_name_lower:
+    async def determine_list_uuid(self) -> str:
+        list_name = EnvironmentVariableGetter.get("BRING_LIST_NAME")
+
+        list_name_lower = list_name.lower()
+        for bring_list in (await self.bring.load_lists())["lists"]:
+            if bring_list["name"].lower() == list_name_lower:
                 bring_list_uuid = bring_list["listUuid"]
-                break
+                self.log.info(f'Found the list with the name "{list_name}" (UUID: {bring_list_uuid})')
+                return bring_list_uuid
 
-        if not bring_list_uuid:
-            self.log.critical(f'Can not find a list with the name "{self.list_name}"')
-            sys.exit(1)
+        self.log.critical(f'Can not find a list with the name "{list_name}"')
+        sys.exit(1)
 
-        self.log.info(f'Found the list with the name "{self.list_name}" (UUID: {bring_list_uuid})')
+    def parse_ignored_ingredients(self) -> list[Ingredient]:
+        try:
+            ignored_ingredients_input = EnvironmentVariableGetter.get("IGNORED_INGREDIENTS")
+        except KeyError:
+            self.log.info(
+                'The variable IGNORED_INGREDIENTS is not set. All ingredients will be added. Consider adding something like "Salt,Pepper"'
+            )
+            return []
 
-        return bring_list_uuid
-
-    def parse_ignored_ingredients(self) -> list[str]:
-        ignored_ingredients = []
-
-        if not self.ignored_ingredients_input:
-            return ignored_ingredients
-
-        ignored_ingredients_input = self.ignored_ingredients_input.lower()
-
-        for ingredient in ignored_ingredients_input.replace(", ", ",").split(","):
-            ignored_ingredients.append(ingredient)
-
-        if ignored_ingredients:
-            self.log.info(f"Ignoring ingredients {ignored_ingredients}")
+        ignored_ingredients = [
+            Ingredient(name) for name in ignored_ingredients_input.lower().replace(", ", ",").split(",")
+        ]
+        self.log.info(f"Ignoring ingredients {Ingredient.to_string_list(ignored_ingredients)}")
 
         return ignored_ingredients
 
-    def add_item_to_list(self, ingredient: Ingredient) -> None:
-        self.log.debug(f"Adding ingredient to Bring: {ingredient}")
+    async def add_items(self, ingredients: list[Ingredient]) -> None:
+        items = [ingredient.to_dict() for ingredient in ingredients]
+        await self.bring.batch_update_list(self.list_uuid, items, BringItemOperation.ADD)
 
-        if ingredient.specification:
-            if self.check_if_food_is_already_in_list(ingredient.food):
-                self.log.info(
-                    f"The food {ingredient.food} is already in the list. Adding its specification in the title"
-                )
-                self.bring.saveItem(self.list_uuid, f"{ingredient.food} ({ingredient.specification})")
-            else:
-                self.bring.saveItem(self.list_uuid, ingredient.food, ingredient.specification)
-        else:
-            self.bring.saveItem(self.list_uuid, ingredient.food)
-
-    def check_if_food_is_already_in_list(self, food: str) -> bool:
-        all_saved_foods = self.bring.getItems(self.list_uuid)["purchase"]
-        for saved_food in all_saved_foods:
-            if saved_food["name"].lower() == food.lower():
-                return True
-        return False
-
-    def notify_users_about_changes_in_list(self) -> None:
+    async def notify_users_about_changes_in_list(self) -> None:
         self.log.debug("Notifying users about changes in shopping list")
-        self.bring.notify(self.list_uuid, BringNotificationType.CHANGED_LIST)
+        await self.bring.notify(self.list_uuid, BringNotificationType.CHANGED_LIST)

--- a/source/bring_handler.py
+++ b/source/bring_handler.py
@@ -15,7 +15,6 @@ class BringHandler(LoggerMixin):
 
         self.bring = loop.run_until_complete(self.initialize())
         self.list_uuid = loop.run_until_complete(self.determine_list_uuid())
-        self.ignored_ingredients = self.parse_ignored_ingredients()
 
     async def initialize(self) -> Bring:
         username = EnvironmentVariableGetter.get("BRING_USERNAME")
@@ -41,22 +40,6 @@ class BringHandler(LoggerMixin):
 
         self.log.critical(f'Can not find a list with the name "{list_name}"')
         sys.exit(1)
-
-    def parse_ignored_ingredients(self) -> list[Ingredient]:
-        try:
-            ignored_ingredients_input = EnvironmentVariableGetter.get("IGNORED_INGREDIENTS")
-        except KeyError:
-            self.log.info(
-                'The variable IGNORED_INGREDIENTS is not set. All ingredients will be added. Consider adding something like "Salt,Pepper"'
-            )
-            return []
-
-        ignored_ingredients = [
-            Ingredient(name) for name in ignored_ingredients_input.lower().replace(", ", ",").split(",")
-        ]
-        self.log.info(f"Ignoring ingredients {Ingredient.to_string_list(ignored_ingredients)}")
-
-        return ignored_ingredients
 
     async def add_items(self, ingredients: list[Ingredient]) -> None:
         items = [ingredient.to_dict() for ingredient in ingredients]

--- a/source/environment_variable_getter.py
+++ b/source/environment_variable_getter.py
@@ -1,4 +1,5 @@
 import os
+from typing import Any
 
 from dotenv import find_dotenv, load_dotenv
 
@@ -10,8 +11,14 @@ load_dotenv(dotenv_path=find_dotenv(".env.override"), override=True)
 
 class EnvironmentVariableGetter:
     @staticmethod
-    def get(name_of_variable: str) -> str:
-        value = os.environ[name_of_variable]
-        if value == "":
-            raise KeyError(f'The environment variable "{name_of_variable}" is not set!')
-        return value
+    def get(name_of_variable: str, default_value: Any = None) -> str:
+        try:
+            value = os.environ[name_of_variable]
+            if value == "":
+                raise KeyError()
+            return value
+        except KeyError:
+            if default_value is not None:
+                return default_value
+
+            raise RuntimeError(f'The environment variable "{name_of_variable}" is not set!') from None

--- a/source/environment_variable_getter.py
+++ b/source/environment_variable_getter.py
@@ -1,0 +1,17 @@
+import os
+
+from dotenv import find_dotenv, load_dotenv
+
+load_dotenv(override=True)
+
+# Load variables from .env.override with higher priority
+load_dotenv(dotenv_path=find_dotenv(".env.override"), override=True)
+
+
+class EnvironmentVariableGetter:
+    @staticmethod
+    def get(name_of_variable: str) -> str:
+        value = os.environ[name_of_variable]
+        if value == "":
+            raise KeyError(f'The environment variable "{name_of_variable}" is not set!')
+        return value

--- a/source/ingredient.py
+++ b/source/ingredient.py
@@ -8,15 +8,10 @@ import uuid
 class Ingredient:
     name: str
     specification: str = None
-    uuid: str = None
 
     @staticmethod
     def from_raw_data(raw_data: dict) -> Ingredient:
-        return Ingredient(
-            name=Ingredient._get_name(raw_data),
-            specification=Ingredient._get_specification(raw_data),
-            uuid=str(uuid.uuid4()),
-        )
+        return Ingredient(name=Ingredient._get_name(raw_data), specification=Ingredient._get_specification(raw_data))
 
     @staticmethod
     def _get_name(raw_data: dict) -> str:
@@ -65,4 +60,4 @@ class Ingredient:
         return [ingredient.name for ingredient in ingredients]
 
     def to_dict(self) -> dict:
-        return {"itemId": self.name, "spec": self.specification, "uuid": self.uuid}
+        return {"itemId": self.name, "spec": self.specification, "uuid": str(uuid.uuid4())}

--- a/source/ingredient.py
+++ b/source/ingredient.py
@@ -19,7 +19,10 @@ class Ingredient:
 
     @staticmethod
     def _get_specification(raw_data: dict) -> str:
-        return f"{Ingredient._get_quantity(raw_data)}{Ingredient._get_unit(raw_data)}{Ingredient._get_note(raw_data)}"
+        specification = f"{Ingredient._get_quantity(raw_data)}{Ingredient._get_unit(raw_data)}"
+        note = Ingredient._get_note(raw_data)
+        specification += note if specification == "" else f" {note}"
+        return specification
 
     @staticmethod
     def _get_quantity(raw_data: dict) -> str:
@@ -53,7 +56,7 @@ class Ingredient:
         if not raw_data["note"]:
             return ""
 
-        return f" ({raw_data['note']})"
+        return f"({raw_data['note']})"
 
     @staticmethod
     def is_ignored(name_of_ingredient: str, ignored_ingredients: list[Ingredient]) -> bool:

--- a/source/ingredient.py
+++ b/source/ingredient.py
@@ -24,12 +24,16 @@ class Ingredient:
     @staticmethod
     def _get_quantity(raw_data: dict) -> str:
         quantity_raw = raw_data["quantity"]
+        if quantity_raw is None:
+            return ""
         quantity = int(quantity_raw) if quantity_raw.is_integer() else quantity_raw
         return str(quantity)
 
     @staticmethod
     def _get_unit(raw_data: dict) -> str:
         unit_raw = raw_data["unit"]
+        if unit_raw is None:
+            return ""
         quantity_is_not_one = raw_data["quantity"] != 1
         if quantity_is_not_one:
             if unit_raw["plural_name"]:
@@ -52,12 +56,8 @@ class Ingredient:
         return f" ({raw_data['note']})"
 
     @staticmethod
-    def is_ignored(raw_data: dict, ignored_ingredients: list[Ingredient]) -> bool:
-        return raw_data["food"]["name"] in Ingredient.to_string_list(ignored_ingredients)
-
-    @staticmethod
-    def to_string_list(ingredients: list[Ingredient]) -> list[str]:
-        return [ingredient.name for ingredient in ingredients]
+    def is_ignored(name_of_ingredient: str, ignored_ingredients: list[Ingredient]) -> bool:
+        return name_of_ingredient.lower() in [ingredient.name for ingredient in ignored_ingredients]
 
     def to_dict(self) -> dict:
         return {"itemId": self.name, "spec": self.specification, "uuid": str(uuid.uuid4())}

--- a/source/ingredient.py
+++ b/source/ingredient.py
@@ -21,8 +21,13 @@ class Ingredient:
     def _get_specification(raw_data: dict) -> str:
         specification = f"{Ingredient._get_quantity(raw_data)}{Ingredient._get_unit(raw_data)}"
         note = Ingredient._get_note(raw_data)
-        specification += note if specification == "" else f" {note}"
-        return specification
+        if specification == "" and note == "":
+            return ""
+        if specification == "":
+            return note
+        if note == "":
+            return specification
+        return f"{specification} {note}"
 
     @staticmethod
     def _get_quantity(raw_data: dict) -> str:

--- a/source/ingredient.py
+++ b/source/ingredient.py
@@ -1,112 +1,68 @@
-from typing import Optional
+from __future__ import annotations
 
-from errors import IgnoredIngredient
-from logger_mixin import LoggerMixin
-
-NO_INGREDIENT_NAME_ERROR = "There is an ingredient with no name, it will be ignored!"
+import dataclasses
+import uuid
 
 
-class Ingredient(LoggerMixin):
-    def __init__(
-        self,
-        ingredient_input: dict,
-        ignored_ingredients: list[str],
-        enable_amount: bool,
-        mealie_version_after_2: bool,
-    ):
-        super().__init__()
+@dataclasses.dataclass
+class Ingredient:
+    name: str
+    specification: str = None
+    uuid: str = None
 
-        self.ingredient_input = ingredient_input
-        self.ignored_ingredients = ignored_ingredients
+    @staticmethod
+    def from_raw_data(raw_data: dict) -> Ingredient:
+        return Ingredient(
+            name=Ingredient._get_name(raw_data),
+            specification=Ingredient._get_specification(raw_data),
+            uuid=str(uuid.uuid4()),
+        )
 
-        self.enable_amount = enable_amount
+    @staticmethod
+    def _get_name(raw_data: dict) -> str:
+        return raw_data["food"]["name"]
 
-        self.food = None
-        self.specification = ""
+    @staticmethod
+    def _get_specification(raw_data: dict) -> str:
+        return f"{Ingredient._get_quantity(raw_data)}{Ingredient._get_unit(raw_data)}{Ingredient._get_note(raw_data)}"
 
-        self.parse_input(mealie_version_after_2)
+    @staticmethod
+    def _get_quantity(raw_data: dict) -> str:
+        quantity_raw = raw_data["quantity"]
+        quantity = int(quantity_raw) if quantity_raw.is_integer() else quantity_raw
+        return str(quantity)
 
-    def __repr__(self):
-        if self.specification:
-            return f"{self.food} ({self.specification})"
-        return self.food
+    @staticmethod
+    def _get_unit(raw_data: dict) -> str:
+        unit_raw = raw_data["unit"]
+        quantity_is_not_one = raw_data["quantity"] != 1
+        if quantity_is_not_one:
+            if unit_raw["plural_name"]:
+                return f" {unit_raw["plural_name"]}"
+            if unit_raw["plural_abbreviation"]:
+                return unit_raw["plural_abbreviation"]
 
-    def parse_input(self, mealie_version_after_2: bool) -> None:
-        self.log.debug(f"Parsing {self.ingredient_input}")
+        if unit_raw["name"]:
+            return f" {unit_raw["name"]}"
+        if unit_raw["abbreviation"]:
+            return unit_raw["abbreviation"]
 
-        if self.enable_amount:
-            self._parse_input_with_ingredient_amounts(mealie_version_after_2)
-        else:
-            self._parse_input_with_no_ingredient_amounts()
+        return ""
 
-        self.log.debug(f"Parsed ingredient: {self}")
+    @staticmethod
+    def _get_note(raw_data: dict) -> str:
+        if not raw_data["note"]:
+            return ""
 
-    def _parse_input_with_no_ingredient_amounts(self) -> None:
-        note = self.ingredient_input["note"]
-        if not note:
-            raise ValueError(NO_INGREDIENT_NAME_ERROR)
-        self.food = note
+        return f" ({raw_data['note']})"
 
-    def _parse_input_with_ingredient_amounts(self, mealie_version_after_2: bool) -> None:
-        if not self.ingredient_input["food"]:
-            # Happens if there is an empty ingredient (i.e., added one ingredient but did not fill it out)
-            raise ValueError(NO_INGREDIENT_NAME_ERROR)
+    @staticmethod
+    def is_ignored(raw_data: dict, ignored_ingredients: list[str]) -> bool:
+        return raw_data["food"]["name"] in ignored_ingredients
 
-        food_name = self.ingredient_input["food"]["name"]
-        if mealie_version_after_2:
-            food_plural_name = self.ingredient_input["food"]["plural_name"]
-        else:
-            food_plural_name = self.ingredient_input["food"]["pluralName"]
-        quantity_raw = self.ingredient_input["quantity"] or 0
-        if int(quantity_raw) == quantity_raw:
-            quantity = int(quantity_raw)
-        else:
-            quantity = quantity_raw
-        unit = self.ingredient_input["unit"]
-        note = self.ingredient_input["note"]
+    @staticmethod
+    def to_string_list(ingredients: list[Ingredient]) -> list[str]:
+        return [ingredient.name for ingredient in ingredients]
 
-        # Ignored check #
-        if food_name.lower() in self.ignored_ingredients:
-            raise IgnoredIngredient(f"Found ignored ingredient {food_name}")
-
-        self._set_food(food_name, food_plural_name, quantity)
-        self._set_quantity(quantity)
-        self._set_seperator(quantity, unit)
-        self._set_unit(quantity, unit, mealie_version_after_2)
-        self._set_note(note)
-
-    def _set_food(self, food_name: str, food_plural_name: str, quantity: int) -> None:
-        if quantity and quantity > 1 and food_plural_name:
-            self.food = food_plural_name
-            return
-
-        self.food = food_name
-
-    def _set_quantity(self, quantity: int) -> None:
-        if quantity:
-            self.specification += str(quantity)
-
-    def _set_seperator(self, quantity: int, unit: Optional[dict]) -> None:
-        if quantity and unit:
-            self.specification += " "
-
-    def _set_unit(self, quantity: int, unit: Optional[dict], mealie_version_after_2: bool) -> None:
-        if not unit:
-            return
-
-        unit_name = unit["name"]
-        unit_abbreviation = unit["abbreviation"]
-        if mealie_version_after_2:
-            unit_plural_name = unit["plural_name"]
-        else:
-            unit_plural_name = unit["pluralName"]
-        if unit_abbreviation:
-            self.specification += unit_abbreviation
-        elif unit_plural_name and quantity and quantity > 1:
-            self.specification += unit_plural_name
-        elif unit_name:
-            self.specification += unit_name
-
-    def _set_note(self, note: str) -> None:
-        if note:
-            self.specification += f" ({note})"
+    def to_dict(self) -> dict:
+        return {"itemId": self.name, "spec": self.specification, "uuid": self.uuid}

--- a/source/ingredient.py
+++ b/source/ingredient.py
@@ -64,3 +64,10 @@ class Ingredient:
 
     def to_dict(self) -> dict:
         return {"itemId": self.name, "spec": self.specification, "uuid": str(uuid.uuid4())}
+
+
+@dataclasses.dataclass
+class IngredientWithAmountsDisabled(Ingredient):
+    @staticmethod
+    def from_raw_data(raw_data: dict) -> Ingredient:
+        return IngredientWithAmountsDisabled(name=raw_data["display"])

--- a/source/ingredient.py
+++ b/source/ingredient.py
@@ -57,8 +57,8 @@ class Ingredient:
         return f" ({raw_data['note']})"
 
     @staticmethod
-    def is_ignored(raw_data: dict, ignored_ingredients: list[str]) -> bool:
-        return raw_data["food"]["name"] in ignored_ingredients
+    def is_ignored(raw_data: dict, ignored_ingredients: list[Ingredient]) -> bool:
+        return raw_data["food"]["name"] in Ingredient.to_string_list(ignored_ingredients)
 
     @staticmethod
     def to_string_list(ingredients: list[Ingredient]) -> list[str]:

--- a/source/logger_mixin.py
+++ b/source/logger_mixin.py
@@ -8,7 +8,7 @@ class LoggerMixin:
         log_level = os.getenv("LOG_LEVEL", "INFO").upper()
         logging.basicConfig(
             stream=sys.stdout,
-            format="[%(asctime)s] [%(name)s] [%(levelname)s] [%(message)s]",
+            format="[%(asctime)s] [%(name)s] [%(levelname)s] %(message)s",
             encoding="utf-8",
             level=log_level,
         )

--- a/source/main.py
+++ b/source/main.py
@@ -1,14 +1,12 @@
 import asyncio
 import logging
-import os
 
 from bring_handler import BringHandler
 from dotenv import load_dotenv
+from environment_variable_getter import EnvironmentVariableGetter
 from flask import Flask, request
 from ingredient import Ingredient
 from logger_mixin import LoggerMixin
-
-from source.environment_variable_getter import EnvironmentVariableGetter
 
 load_dotenv()
 
@@ -60,7 +58,7 @@ def status_handler() -> str:
 def parse_ignored_ingredients() -> list[Ingredient]:
     try:
         ignored_ingredients_input = EnvironmentVariableGetter.get("IGNORED_INGREDIENTS")
-    except KeyError:
+    except RuntimeError:
         logger.log.info(
             'The variable IGNORED_INGREDIENTS is not set. All ingredients will be added. Consider adding something like "Salt,Pepper"'
         )
@@ -80,7 +78,7 @@ if __name__ == "__main__":
     bring_handler = BringHandler(loop)
     ignored_ingredients = parse_ignored_ingredients()
 
-    host = os.getenv("HTTP_HOST", "0.0.0.0")
-    port = int(os.getenv("HTTP_PORT", 8742))
+    host = EnvironmentVariableGetter.get("HTTP_HOST", "0.0.0.0")
+    port = int(EnvironmentVariableGetter.get("HTTP_PORT", 8742))
     logger.log.info(f"Listening on {host}:{port}")
     app.run(host=host, port=port)

--- a/source/main.py
+++ b/source/main.py
@@ -1,9 +1,9 @@
+import asyncio
 import logging
 import os
 
 from bring_handler import BringHandler
 from dotenv import load_dotenv
-from errors import IgnoredIngredient
 from flask import Flask, request
 from ingredient import Ingredient
 from logger_mixin import LoggerMixin
@@ -17,19 +17,9 @@ app = Flask(__name__)
 def webhook_handler() -> str:
     data = request.get_json(force=True)
 
-    mealie_version_after_2 = True
-    if "name" in data.keys():
-        mealie_version_after_2 = False
+    logger.log.info(f'Received recipe "{data["content"]["name"]}" from "{request.remote_addr}"')
 
-    if mealie_version_after_2:
-        logger.log.info(f'Received recipe "{data["content"]["name"]}" from "{request.remote_addr}"')
-    else:
-        logger.log.info(f'Received recipe "{data["name"]}" from "{request.remote_addr}"')
-
-    if mealie_version_after_2:
-        enable_amount = not data["content"]["settings"]["disable_amount"]
-    else:
-        enable_amount = not data["settings"]["disableAmount"]
+    enable_amount = not data["content"]["settings"]["disable_amount"]
     if enable_amount:
         logger.log.debug("This recipe has its ingredient amount enabled")
     else:
@@ -37,29 +27,21 @@ def webhook_handler() -> str:
             "This recipe has its ingredient amount this disabled --> Its ingredients will not be checked whether they are supposed to be ignored"
         )
 
-    if mealie_version_after_2:
-        ingredients = data["content"]["recipe_ingredient"]
-    else:
-        ingredients = data["recipeIngredient"]
-    for ingredient in ingredients:
+    ingredients_to_add = []
+    ingredients_raw_data = data["content"]["recipe_ingredient"]
+    for ingredient_raw_data in ingredients_raw_data:
+        if Ingredient.is_ignored(ingredient_raw_data, bring_handler.ignored_ingredients):
+            logger.log.debug(f"Ignoring ingredient {ingredient_raw_data}")
+
         try:
-            parsed_ingredient = Ingredient(
-                ingredient,
-                bring_handler.ignored_ingredients,
-                enable_amount,
-                mealie_version_after_2,
-            )
+            ingredients_to_add.append(Ingredient.from_raw_data(ingredient_raw_data))
         except ValueError as e:
             logger.log.warning(e)
             continue
-        except IgnoredIngredient as e:
-            logger.log.debug(e)
-            continue
 
-        bring_handler.add_item_to_list(parsed_ingredient)
-
-    logger.log.info("Added all ingredients to Bring")
-    bring_handler.notify_users_about_changes_in_list()
+    logger.log.info(f"Adding ingredients to Bring: {ingredients_to_add}")
+    loop.run_until_complete(bring_handler.add_items(ingredients_to_add))
+    loop.run_until_complete(bring_handler.notify_users_about_changes_in_list())
 
     return "OK"
 
@@ -73,12 +55,12 @@ def status_handler() -> str:
 if __name__ == "__main__":
     logger = LoggerMixin()
     logger.log = logging.getLogger("Main")
-    bring_handler = BringHandler()
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+
+    bring_handler = BringHandler(loop)
 
     host = os.getenv("HTTP_HOST", "0.0.0.0")
     port = int(os.getenv("HTTP_PORT", 8742))
     logger.log.info(f"Listening on {host}:{port}")
-    app.run(
-        host=host,
-        port=port,
-    )
+    app.run(host=host, port=port)

--- a/source/main.py
+++ b/source/main.py
@@ -8,6 +8,8 @@ from flask import Flask, request
 from ingredient import Ingredient
 from logger_mixin import LoggerMixin
 
+from source.environment_variable_getter import EnvironmentVariableGetter
+
 load_dotenv()
 
 app = Flask(__name__)
@@ -30,13 +32,13 @@ def webhook_handler() -> str:
     ingredients_to_add = []
     ingredients_raw_data = data["content"]["recipe_ingredient"]
     for ingredient_raw_data in ingredients_raw_data:
-        if Ingredient.is_ignored(ingredient_raw_data, bring_handler.ignored_ingredients):
+        if Ingredient.is_ignored(ingredient_raw_data, ignored_ingredients):
             logger.log.debug(f"Ignoring ingredient {ingredient_raw_data}")
 
         try:
             ingredients_to_add.append(Ingredient.from_raw_data(ingredient_raw_data))
-        except ValueError as e:
-            logger.log.warning(e)
+        except ValueError:
+            logger.log.warning(exc_info=True)
             continue
 
     logger.log.info(f"Adding ingredients to Bring: {ingredients_to_add}")
@@ -52,6 +54,23 @@ def status_handler() -> str:
     return "OK"
 
 
+def parse_ignored_ingredients() -> list[Ingredient]:
+    try:
+        ignored_ingredients_input = EnvironmentVariableGetter.get("IGNORED_INGREDIENTS")
+    except KeyError:
+        logger.log.info(
+            'The variable IGNORED_INGREDIENTS is not set. All ingredients will be added. Consider adding something like "Salt,Pepper"'
+        )
+        return []
+
+    ignored_ingredients = [
+        Ingredient(name) for name in ignored_ingredients_input.lower().replace(", ", ",").split(",")
+    ]
+    logger.log.info(f"Ignoring ingredients {Ingredient.to_string_list(ignored_ingredients)}")
+
+    return ignored_ingredients
+
+
 if __name__ == "__main__":
     logger = LoggerMixin()
     logger.log = logging.getLogger("Main")
@@ -59,6 +78,7 @@ if __name__ == "__main__":
     asyncio.set_event_loop(loop)
 
     bring_handler = BringHandler(loop)
+    ignored_ingredients = parse_ignored_ingredients()
 
     host = os.getenv("HTTP_HOST", "0.0.0.0")
     port = int(os.getenv("HTTP_PORT", 8742))

--- a/source/main.py
+++ b/source/main.py
@@ -32,10 +32,13 @@ def webhook_handler() -> str:
     ingredients_to_add = []
     ingredients_raw_data = data["content"]["recipe_ingredient"]
     for ingredient_raw_data in ingredients_raw_data:
-        if Ingredient.is_ignored(ingredient_raw_data, ignored_ingredients):
-            logger.log.debug(f"Ignoring ingredient {ingredient_raw_data}")
+        name_of_ingredient = ingredient_raw_data["food"]["name"]
+        if Ingredient.is_ignored(name_of_ingredient, ignored_ingredients):
+            logger.log.debug(f"Ignoring ingredient {name_of_ingredient}")
+            continue
 
         try:
+            logger.log.debug(f"Parsing ingredient {ingredient_raw_data}")
             ingredients_to_add.append(Ingredient.from_raw_data(ingredient_raw_data))
         except ValueError:
             logger.log.warning(exc_info=True)
@@ -63,12 +66,9 @@ def parse_ignored_ingredients() -> list[Ingredient]:
         )
         return []
 
-    ignored_ingredients = [
-        Ingredient(name) for name in ignored_ingredients_input.lower().replace(", ", ",").split(",")
-    ]
-    logger.log.info(f"Ignoring ingredients {Ingredient.to_string_list(ignored_ingredients)}")
-
-    return ignored_ingredients
+    ignored_ingredients_raw = ignored_ingredients_input.replace(", ", ",").split(",")
+    logger.log.info(f"Ignoring ingredients {ignored_ingredients_raw}")
+    return [Ingredient(name.lower()) for name in ignored_ingredients_raw]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Migrated from the old unmaintained [python-bring-api](https://github.com/eliasball/python-bring-api) to [a new version of the library](https://github.com/miaucl/bring-api).

Benefits:

- Faster adding of ingredients (all ingredients are added at once rather than one at a time)
- Move away from a deprecated library
- All ingredients can be added multiple times now with the same or different specifications. It is now possible to add `Noodels` and `Noodels` and `Noodels 200g` and `Noodles 500g` and `Noodles (or rice)` to the same list
  - Fixes https://github.com/felixschndr/mealie-bring-api/issues/13
  - Enables a workaround for https://github.com/felixschndr/mealie-bring-api/issues/15: If you want to add 2 servings just run the action in Mealie twice. 
  
I tested it with my data in Mealie. Feel free to do so yourself by using the image `ghcr.io/felixschndr/mealie-bring-api:feat-migrate-bring-library`. I am happy to hear from you about any feedback or issues.

> [!WARNING]
> This deprecates the support for Mealie version < 2