### PR TITLE
Remove deprecated `IGNORED_INGREDIENTS` variable and references

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ Mealie instance and adds the ingredients of a recipe to a specified Bring shoppi
 > [!IMPORTANT]  
 > This integration does only support Mealie version >= `2` which was [released in October 2024](https://github.com/mealie-recipes/mealie/releases/tag/v2.0.0). The support for Mealie version < `2` was deprecated in https://github.com/felixschndr/mealie-bring-api/pull/17.
 
-> [!IMPORTANT]  
-> The environment variable `IGNORED_INGREDIENTS` was deprecated in [PR24](https://github.com/felixschndr/mealie-bring-api/pull/24) and is now ignored. If you are using it, migrate to the
-new way of configuring which ingredients shall be ignored. See [down below](https://github.com/felixschndr/mealie-bring-api?tab=readme-ov-file#ignoring-ingredients)
+
 
 ## Architecture
 
@@ -51,6 +49,10 @@ No matter which deployment option you chose you must setup some environment vari
 | `HTTP_BASE_PATH`      | The path the application listens on. Use this if you use the app behind a reverse proxy and have setup a path (e.g. set this to `/bring` if the application shall listen on `<mealie>.<yourdomain>.tld/bring`)                                                                             |    No    | `""`                              | `/bring`                       |
 
 Ensure to quote your environment variables. Without quotes your password might not be read properly if it contains symbols such as `<`, `&` or `;`.
+
+> [!IMPORTANT]  
+> The environment variable `IGNORED_INGREDIENTS` was deprecated
+in [PR24](https://github.com/felixschndr/mealie-bring-api/pull/24) and is now ignored. If you are using it, migrate to the new way of configuring which ingredients shall be ignored as seen below.
 
 #### Ignoring ingredients
 

--- a/assets/.env.example
+++ b/assets/.env.example
@@ -2,7 +2,6 @@
 BRING_USERNAME="myuser@myemailprovider.com"
 BRING_PASSWORD="mysupersecretpassword"
 BRING_LIST_NAME="My list has some spaces in it"
-IGNORED_INGREDIENTS="Pepper,Salt"
 LOG_LEVEL=INFO
 HTTP_HOST=0.0.0.0
 HTTP_PORT=8742

--- a/assets/docker-compose-example.yml
+++ b/assets/docker-compose-example.yml
@@ -22,4 +22,3 @@ services:
       BRING_USERNAME: myuser@myemailprovider.com
       BRING_PASSWORD: mysupersecretpassword
       BRING_LIST_NAME: My list has some spaces in it
-      IGNORED_INGREDIENTS: Pepper,Salt,Fying Oil

--- a/source/errors.py
+++ b/source/errors.py
@@ -1,2 +1,0 @@
-class IgnoredIngredient(Exception):
-    pass

--- a/source/main.py
+++ b/source/main.py
@@ -54,24 +54,11 @@ def status_handler() -> str:
     return "OK"
 
 
-def check_for_ignored_ingredients() -> None:
-    try:
-        EnvironmentVariableGetter.get("IGNORED_INGREDIENTS")
-        logger.log.warning(
-            "The variable IGNORED_INGREDIENTS is deprecated and ignored! "
-            "Take a look README.md for more information on how to ignore ingredients."
-        )
-    except RuntimeError:
-        pass
-
-
 if __name__ == "__main__":
     logger = LoggerMixin()
     logger.log = logging.getLogger("Main")
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
-
-    check_for_ignored_ingredients()
 
     bring_handler = BringHandler(loop)
 


### PR DESCRIPTION
This option was deprecated for some time now. Removed the check from the code and references in config files