### PR TITLE
Add network debugging tools to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,13 @@ WORKDIR /app
 
 EXPOSE 8742/tcp
 
+RUN apk add --no-cache \
+    bash \
+    curl \
+    iproute2 \
+    bind-tools \
+    busybox-extras
+
 COPY source/ source/
 COPY pyproject.toml .
 COPY poetry.lock .
@@ -14,5 +21,7 @@ COPY poetry.lock .
 RUN pip install poetry && \
     POETRY_VIRTUALENVS_CREATE=false poetry install && \
     pip uninstall -y poetry
+
+SHELL ["/bin/bash", "-c"]
 
 CMD python -m source.mealie_bring_api


### PR DESCRIPTION
Followup of https://github.com/felixschndr/mealie-bring-api/pull/32#issuecomment-3469612148

@FunkyKwak I create this image for you with some network debugging tools like `host`, `ip`, `dig`, `nslookup`, `curl`, `ping` and `traceroute`. With them you should be able to debug your networking issue.
First, make sure that you have the correct host or ip of the mealie container and the name lookup works and then you should be able to figure the port out.

The image can be be pulled with `docker pull ghcr.io/felixschndr/mealie-bring-api:test-add-debugging-tools-to-container-image` and you can enter into the shell with `docker exec -it "<container name>" /bin/bash`